### PR TITLE
Add anilist rate limiting and currentSeason functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Parameters:
 - countryOfOrigin: [CountryCode](https://studio.apollographql.com/sandbox/schema/reference/scalars/CountryCode)
 - season: [MediaSeason](https://studio.apollographql.com/sandbox/schema/reference/enums/MediaSeason)
 - seasonYear: Int
+- currentSeason: Boolean (This overrides the season and seasonYear to fetch the most current season)
 - year: String
 - onList: Boolean
 - yearLesser: [FuzzyDateInt](https://studio.apollographql.com/sandbox/schema/reference/scalars/FuzzyDateInt)
@@ -50,7 +51,6 @@ Parameters:
 - limit: Int
 - allowDuplicates: Boolean
 - mergeSeasons: Boolean
-- currentSeason: Boolean
 
 Example request:
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Parameters:
 - limit: Int
 - allowDuplicates: Boolean
 - mergeSeasons: Boolean
+- currentSeason: Boolean
 
 Example request:
 ```bash

--- a/anilist.go
+++ b/anilist.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const anilistQuery = `
@@ -131,6 +132,13 @@ func SearchOptsFromAniListRequest(r *http.Request) (*SearchOpts, error) {
 	// dont include limit in the AniList api call as its already hard coded at 20 per page
 	q.Del("limit")
 
+	if parseBoolParam(q, "currentSeason") {
+		season, year := CurrentAnimeSeason(time.Now())
+		q.Set("season", season)
+		q.Set("seasonYear", strconv.Itoa(year))
+		q.Del("currentSeason")
+	}
+
 	q.Set("type", "ANIME")
 
 	skipDedup := parseBoolParam(q, "allowDuplicates")
@@ -144,8 +152,11 @@ func SearchOptsFromAniListRequest(r *http.Request) (*SearchOpts, error) {
 	}, nil
 }
 
-func makeAniListApiCall(q url.Values) (*AniListApiResponse, error) {
-	// Build the GraphQL request body
+type AniListRateLimitInfo struct {
+	Remaining int
+}
+
+func makeAniListApiCall(q url.Values) (*AniListApiResponse, *AniListRateLimitInfo, error) {
 	variables := BuildGraphQLVariables(q)
 
 	body := map[string]any{
@@ -154,26 +165,43 @@ func makeAniListApiCall(q url.Values) (*AniListApiResponse, error) {
 	}
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// Make the POST request
-	resp, err := http.Post("https://graphql.anilist.co", "application/json", bytes.NewBuffer(jsonBody))
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
+	for {
+		resp, err := http.Post("https://graphql.anilist.co", "application/json", bytes.NewBuffer(jsonBody))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		rl := &AniListRateLimitInfo{Remaining: -1}
+		if v, err := strconv.Atoi(resp.Header.Get("X-RateLimit-Remaining")); err == nil {
+			rl.Remaining = v
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			retryAfter := 60
+			if v, err := strconv.Atoi(resp.Header.Get("Retry-After")); err == nil && v > 0 {
+				retryAfter = v
+			}
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				log.Printf("Error closing response body: %v", closeErr)
+			}
+			log.Printf("AniList rate limit exceeded, retrying after %d seconds...", retryAfter)
+			time.Sleep(time.Duration(retryAfter) * time.Second)
+			continue
+		}
+
+		respData := new(AniListApiResponse)
+		err = json.NewDecoder(resp.Body).Decode(respData)
 		if closeErr := resp.Body.Close(); closeErr != nil {
 			log.Printf("Error closing response body: %v", closeErr)
 		}
-	}()
-
-	respData := new(AniListApiResponse)
-	err = json.NewDecoder(resp.Body).Decode(respData)
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, nil, err
+		}
+		return respData, rl, nil
 	}
-	return respData, nil
 }
 
 // BuildGraphQLVariables converts URL query parameters into a GraphQL variables map.

--- a/consumer.go
+++ b/consumer.go
@@ -74,6 +74,7 @@ func makeApiRequest(idMap *ConcurrentMap, target SupportedAPI, opts *SearchOpts)
 	count := 0
 	usedIds := make(map[int]bool, 0)
 	usedTvdbIds := make(map[int]bool, 0)
+	anilistRemaining := -1
 
 	for hasNextPage {
 
@@ -105,12 +106,13 @@ func makeApiRequest(idMap *ConcurrentMap, target SupportedAPI, opts *SearchOpts)
 			if cachedResult, found := Cache.Get(fmt.Sprint(AniList) + opts.Query.Encode()); found {
 				result = cachedResult.(*AniListApiResponse)
 			} else {
-				newResult, err := makeAniListApiCall(opts.Query)
+				newResult, rl, err := makeAniListApiCall(opts.Query)
 				if err != nil {
 					log.Println("Error sending request to AniList: ", err)
 					return nil, err
 				}
 				result = newResult
+				anilistRemaining = rl.Remaining
 				Cache.Set(fmt.Sprint(AniList)+opts.Query.Encode(), newResult, cache.DefaultExpiration)
 			}
 			for _, item := range result.Data.Page.Media {
@@ -157,7 +159,10 @@ func makeApiRequest(idMap *ConcurrentMap, target SupportedAPI, opts *SearchOpts)
 			break
 		}
 		if hasNextPage {
-			time.Sleep(500 * time.Millisecond) // sleep between requests for new page to try and avoid rate limits
+			if anilistRemaining == 0 {
+				log.Println("AniList rate limit nearly exhausted, waiting 60 seconds before next page...")
+				time.Sleep(60 * time.Second)
+			}
 		}
 	}
 

--- a/helpers.go
+++ b/helpers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 )
 
 // parses the boolean param "name" from url.Values "values"
@@ -33,4 +34,21 @@ func FullAnimeTitle(title, engtitle string) string {
 
 func RequestString(r *http.Request) string {
 	return fmt.Sprintf("%s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+}
+
+// CurrentAnimeSeason returns the AniList season name and year for the given time,
+// following the same quarter mapping used by AniList and AniChart.
+func CurrentAnimeSeason(t time.Time) (season string, year int) {
+	year = t.Year()
+	switch t.Month() {
+	case time.January, time.February, time.March:
+		season = "WINTER"
+	case time.April, time.May, time.June:
+		season = "SPRING"
+	case time.July, time.August, time.September:
+		season = "SUMMER"
+	default:
+		season = "FALL"
+	}
+	return
 }


### PR DESCRIPTION
Update anilist to pass through rate limiting and allow for respecting the rate limit that anilist is sending back.
Add currentSeason functionality to the anilist search to override the season and seasonYear. This will allow the user to fetch the most current season instead of having to update the season and seasonYear.